### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:1.2.1")
     implementation("net.ltgt.gradle:gradle-apt-plugin:0.21")
     implementation("com.github.jengelman.gradle.plugins:shadow:6.0.0")
-    implementation("gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:2.4.0")
+    implementation("gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:2.5.0")
     implementation("io.spine.tools:spine-bootstrap:1.5.24")
     implementation("net.saliman:gradle-properties-plugin:1.5.1")
 }

--- a/buildSrc/src/main/kotlin/dependency-management.gradle.kts
+++ b/buildSrc/src/main/kotlin/dependency-management.gradle.kts
@@ -18,24 +18,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import net.saliman.gradle.plugin.properties.PropertiesPlugin
-
 plugins {
-    idea
+    java
 }
 
-apply(from = "version.gradle.kts")
-val botVersion: String by extra
-
-allprojects {
-    apply<IdeaPlugin>()
-    apply<PropertiesPlugin>()
-
-    group = "io.spine"
-    version = botVersion
-}
-
-subprojects {
-    apply<JavaConventionPlugin>()
-    apply<DependencyManagementPlugin>()
+configurations.all {
+    resolutionStrategy {
+        force(
+                Deps.build.guava,
+                Deps.build.errorProneAnnotations,
+                Deps.build.spine.base,
+                Deps.build.spine.core,
+                Deps.build.spine.server,
+                Deps.build.spine.client
+        )
+    }
 }

--- a/buildSrc/src/main/kotlin/deps.kt
+++ b/buildSrc/src/main/kotlin/deps.kt
@@ -30,6 +30,8 @@ object Versions {
     const val truth = "1.0.1"
     const val micronaut = "2.0.1"
     const val spineGcloud = "1.5.22"
+    const val spineBase = "1.5.23"
+    const val spineCore = "1.5.24"
     const val googleSecretManager = "1.1.1"
     const val googleChat = "v1-rev20200801-1.30.10"
     const val googleAuth = "0.21.1"
@@ -62,6 +64,10 @@ object Build {
 object Spine {
     const val datastore = "io.spine.gcloud:spine-datastore:${Versions.spineGcloud}"
     const val pubsub = "io.spine.gcloud:spine-pubsub:${Versions.spineGcloud}"
+    const val base = "io.spine:spine-base:${Versions.spineBase}"
+    const val server = "io.spine:spine-server:${Versions.spineCore}"
+    const val client = "io.spine:spine-client:${Versions.spineCore}"
+    const val core = "io.spine:spine-core:${Versions.spineCore}"
 }
 
 object Log4j2 {

--- a/buildSrc/src/main/kotlin/deps.kt
+++ b/buildSrc/src/main/kotlin/deps.kt
@@ -19,20 +19,20 @@
  */
 
 object Versions {
-    const val checkerFramework = "3.4.1"
+    const val checkerFramework = "3.6.0"
     const val errorProne = "2.4.0"
-    const val pmd = "6.24.0"
-    const val checkstyle = "8.33"
+    const val pmd = "6.26.0"
+    const val checkstyle = "8.35"
     const val findBugs = "3.0.2"
     const val guava = "29.0-jre"
     const val flogger = "0.5.1"
     const val junit5 = "5.6.2"
     const val truth = "1.0.1"
-    const val micronaut = "2.0.0"
+    const val micronaut = "2.0.1"
     const val spineGcloud = "1.5.22"
-    const val googleSecretManager = "1.1.0"
-    const val googleChat = "v1-rev20200617-1.30.9"
-    const val googleAuth = "0.20.0"
+    const val googleSecretManager = "1.1.1"
+    const val googleChat = "v1-rev20200801-1.30.10"
+    const val googleAuth = "0.21.1"
     const val log4j2 = "2.13.3"
 }
 

--- a/buildSrc/src/main/kotlin/java-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-convention.gradle.kts
@@ -21,7 +21,7 @@
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
-    `java-library`
+    java
     id("net.ltgt.errorprone")
     id("net.ltgt.apt-idea")
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   # The following step starts the build process using Gradle official image, performs the build
   # and runs `jib` for the specified `gcpProject` in order to build and deploy the container
   # image to the Google Container Registry.
-  - name: 'gradle:6.4.1-jdk11'
+  - name: 'gradle:6.6-jdk11'
     entrypoint: 'gradle'
     args: [ 'build', 'jib', '-PgcpProject=${PROJECT_ID}' ]
   # The following step deploys the previously produced container image to the Cloud Run environment

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Jun 15 15:39:45 EEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -22,4 +22,4 @@
  * The version of the application.
  */
 
-val botVersion: String by extra("1.0.0")
+val botVersion: String by extra("1.1.0")


### PR DESCRIPTION
In this PR I have migrated to the latest Gradle v6.6 version as well as updated core application dependencies.

The most desired update is the new version of the `base` library with Java9+ time fix (see https://github.com/SpineEventEngine/base/pull/554 for details).

In order to be able to force `base` version, I defined the dependency resolution strategy that overrides the `bootstrap` plugin version management.