### PR TITLE
Make sure we use the new `postAndForget` API

### DIFF
--- a/google-chat-bot/src/main/java/io/spine/chatbot/client/Client.java
+++ b/google-chat-bot/src/main/java/io/spine/chatbot/client/Client.java
@@ -105,11 +105,10 @@ public final class Client implements AutoCloseable {
      */
     public void post(CommandMessage command) {
         checkNotNull(command);
-        var subscriptions = client.asGuest()
-                                  .command(command)
-                                  .onStreamingError(Client::throwProcessingError)
-                                  .post();
-        subscriptions.forEach(this::cancelSubscription);
+        client.asGuest()
+              .command(command)
+              .onStreamingError(Client::throwProcessingError)
+              .postAndForget();
     }
 
     private <E extends EventMessage> void

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -22,4 +22,4 @@
  * The version of the application.
  */
 
-val botVersion: String by extra("1.1.0")
+val botVersion: String by extra("1.1.1")


### PR DESCRIPTION
Make sure we use the new `postAndForget` API where the observing events have no value.