### PR TITLE
Fix Cloud Build `jib` config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,11 +26,11 @@
 
 steps:
   # The following step starts the build process using Gradle official image, performs the build
-  # and runs `jib` for the specified `gcpProject` in order to build and deploy the container
+  # and runs `jib` for the specified `GCP_PROJECT` in order to build and deploy the container
   # image to the Google Container Registry.
   - name: 'gradle:6.9-jdk11'
     entrypoint: 'gradle'
-    args: [ 'build', 'jib', '-PgcpProject=${PROJECT_ID}' ]
+    args: [ 'build', 'jib', '-PGCP_PROJECT=${PROJECT_ID}' ]
   # The following step deploys the previously produced container image to the Cloud Run environment
   # with the pre-configured `GCP_PROJECT_ID` environment variable.
   - name: 'google/cloud-sdk:slim'


### PR DESCRIPTION
This PR fixes usage of the `gcpProject` Gradle param changed in the previous PR to `GCP_PROJECT`.